### PR TITLE
Create isacikgoz-govatar.md

### DIFF
--- a/hackathon-submissions/isacikgoz-govatar.md
+++ b/hackathon-submissions/isacikgoz-govatar.md
@@ -1,0 +1,13 @@
+### Mattermost Govatar Support
+
+If enabled from the experimental settings, server uses [Govatar](https://github.com/o1egl/govatar) to create the users empty-avatar instead of using the leter+color image 
+
+![image](https://user-images.githubusercontent.com/2153367/102118064-3f957f80-3e50-11eb-8055-8d36a5a01850.png)
+
+Guesses the genders by the user's firstname and their locale.
+
+![image](https://user-images.githubusercontent.com/2153367/102118166-62279880-3e50-11eb-8fbf-667c165057d0.png)
+
+### Repository
+
+https://github.com/mattermost/mattermost-server/tree/govatar


### PR DESCRIPTION

#### Summary

Mattermost-server uses [Govatar](https://github.com/o1egl/govatar) to create the users empty-avatar instead of using the leter+color image 
